### PR TITLE
do not render front-matter by default

### DIFF
--- a/markdown-pdf.js
+++ b/markdown-pdf.js
@@ -130,6 +130,9 @@ function convertMarkdownToHtml(filename, type, text, config) {
   // checkbox
   md.use(require("markdown-it-checkbox"))
 
+  // ignore front-matter
+  md.use(require("markdown-it-front-matter"), (frontMatter) => '');
+
   // emoji
   let f = config["emoji"]
   if (f) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "markdown-it-checkbox": "^1.1.0",
     "markdown-it-container": "^3.0.0",
     "markdown-it-emoji": "^2.0.2",
+    "markdown-it-front-matter": "^0.2.3",
     "markdown-it-include": "^2.0.0",
     "markdown-it-named-headers": "0.0.4",
     "markdown-it-plantuml": "^1.0.0",


### PR DESCRIPTION
This fixes #30 

Given teh following markdown, the included front-matter should not be rendered:
```markdown
---
@author Alexander Wunschik
@license MIT
---

# Header 1
```

without this fix:
![image](https://github.com/djfdyuruiry/pretty-markdown-pdf/assets/600565/e7e71e1d-0f4f-48ea-9f8f-fe2bcf98540f)

with this fix:
![image](https://github.com/djfdyuruiry/pretty-markdown-pdf/assets/600565/2e572b47-f69c-4285-807c-ee4b1d21ee40)

